### PR TITLE
An extra table floating header was added when we implement sticky hea…

### DIFF
--- a/addon/components/table-columns.js
+++ b/addon/components/table-columns.js
@@ -132,8 +132,8 @@ export default Ember.Component.extend({
   },
 
   _onRowEnter() {
-    let rowIndex = this.$('tr').index(this.$('tr:hover'));
-    this.getAttr('table').$(`tr.table-row:nth-child(${rowIndex})`).addClass('hover');
+    let rowIndex = this.$('tbody tr').index(this.$('tr:hover'));
+    this.getAttr('table').$(`tr.table-row:nth-child(${rowIndex + 1})`).addClass('hover');
   },
 
   _onRowLeave() {


### PR DESCRIPTION
An extra table floating header was added when we implement sticky header, this header includes a <tr> element that was causing to not get the right row index.

Now we are getting the index using an specific selector to the tbody rows and then we just add one to it to get te proper nth-child.
